### PR TITLE
fix the case when toJSON() returns a Buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = hasBinary;
 
 function hasBinary(data) {
 
-  function _hasBinary(obj) {
+  function _hasBinary(obj, afterToJSON) {
     if (!obj) return false;
 
     if ( (global.Buffer && global.Buffer.isBuffer && global.Buffer.isBuffer(obj)) ||
@@ -41,8 +41,9 @@ function hasBinary(data) {
       }
     } else if (obj && 'object' == typeof obj) {
       // see: https://github.com/Automattic/has-binary/pull/4
-      if (obj.toJSON && 'function' == typeof obj.toJSON) {
-        obj = obj.toJSON();
+      // also: toJSON() can return any type. Restart the check, but don't call toJSON twice
+      if (!afterToJSON && obj.toJSON && 'function' == typeof obj.toJSON) {
+        return _hasBinary(obj.toJSON(), true);
       }
 
       for (var key in obj) {

--- a/test.js
+++ b/test.js
@@ -29,6 +29,11 @@ describe('has-binarydata', function(){
     assert(hasBinary(ob));
   });
 
+  it('should work with an object whose toJSON() returns a buffer', function() {
+    var ob = {a: 'a', b: [], c: 1234, toJSON: function() { return new Buffer('abc') }};
+    assert(hasBinary(ob));
+  });
+
   it('should work with null', function() {
     assert(!hasBinary(null));
   });


### PR DESCRIPTION
has-binary assumes that toJSON() returns an object, but this is not necessary.
It incorrectly returns false for objects whose toJSON() returns a Buffer, eg:

```
{ a: 'a', toJSON: function() { return new Buffer('abc') } }
```

Returning Buffer from toJSON is useful for classes who want to serialize themselves in binary when sent over socket.io.

The fix is simple, I also added a test.
