### PR TITLE
Ensure globals are functions before running `instanceof` checks

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,10 +25,10 @@ function hasBinary(data) {
   function _hasBinary(obj) {
     if (!obj) return false;
 
-    if ( (global.Buffer && global.Buffer.isBuffer && global.Buffer.isBuffer(obj)) ||
-         (global.ArrayBuffer && obj instanceof ArrayBuffer) ||
-         (global.Blob && obj instanceof Blob) ||
-         (global.File && obj instanceof File)
+    if ( (typeof global.Buffer === 'function' && global.Buffer.isBuffer && global.Buffer.isBuffer(obj)) ||
+         (typeof global.ArrayBuffer === 'function' && obj instanceof ArrayBuffer) ||
+         (typeof global.Blob === 'function' && obj instanceof Blob) ||
+         (typeof global.File === 'function' && obj instanceof File)
         ) {
       return true;
     }

--- a/test.js
+++ b/test.js
@@ -70,4 +70,12 @@ describe('has-binarydata', function(){
      });
   }
 
+  else {
+    it('should not crash if global Blob is not a function', function() {
+      global.Blob = [ 1, 2, 3 ];
+      hasBinary(global.Blob);
+      return;
+    });    
+  }
+
 });


### PR DESCRIPTION
`File` and `Blob` don't exist in Node, and `Buffer` and `ArrayBuffer` don't exist in HTML5.  So if an app uses those globals for some other purpose and also uses `has-binary`, it can crash with a "TypeError: Expecting a function in instanceof check, but got <whatever>" error.  This commit fixes that issue.

refs https://github.com/socketio/socket.io/issues/2871