### PR TITLE
do not call toJSON more than once

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,8 +44,8 @@ function hasBinary (obj) {
   }
 
   // see: https://github.com/Automattic/has-binary/pull/4
-  if (obj.toJSON && typeof obj.toJSON === 'function') {
-    return hasBinary(obj.toJSON());
+  if (obj.toJSON && typeof obj.toJSON === 'function' && arguments.length === 1) {
+    return hasBinary(obj.toJSON(), true);
   }
 
   for (var key in obj) {

--- a/test.js
+++ b/test.js
@@ -34,6 +34,11 @@ describe('has-binarydata', function () {
     assert(hasBinary(ob));
   });
 
+  it('should work with an object by calling toJSON() once', function () {
+    var ob = { toJSON: function () { return this; } };
+    assert(!hasBinary(ob));
+  });
+
   it('should work with null', function () {
     assert(!hasBinary(null));
   });


### PR DESCRIPTION
In order to match JSON.stringify's behaviour:

> var o = { toJSON: function() { return this; } };
> JSON.stringify(o)
'{}'
> hasBinary(o)
false (previously "RangeError: Maximum call stack size exceeded")